### PR TITLE
Using mutex for fetchToken to eliminate race condition

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@nestjs/swagger": "5.1.5",
         "@nestjs/throttler": "2.0.0",
         "@vechain/connex": "2.0.7",
+        "async-mutex": "0.3.2",
         "class-transformer": "0.5.1",
         "class-validator": "0.13.2",
         "coingecko-api": "1.0.10",
@@ -3632,6 +3633,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/async-mutex": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.3.2.tgz",
+      "integrity": "sha512-HuTK7E7MT7jZEh1P9GtRW9+aTWiDWWi9InbZ5hjxrnRa39KS4BW04+xLBhYNS2aXhHUIKZSw3gj4Pn1pj+qGAA==",
+      "dependencies": {
+        "tslib": "^2.3.1"
       }
     },
     "node_modules/asynckit": {
@@ -13927,6 +13936,14 @@
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3",
         "es-abstract": "^1.19.0"
+      }
+    },
+    "async-mutex": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.3.2.tgz",
+      "integrity": "sha512-HuTK7E7MT7jZEh1P9GtRW9+aTWiDWWi9InbZ5hjxrnRa39KS4BW04+xLBhYNS2aXhHUIKZSw3gj4Pn1pj+qGAA==",
+      "requires": {
+        "tslib": "^2.3.1"
       }
     },
     "asynckit": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@nestjs/swagger": "5.1.5",
     "@nestjs/throttler": "2.0.0",
     "@vechain/connex": "2.0.7",
+    "async-mutex": "0.3.2",
     "class-transformer": "0.5.1",
     "class-validator": "0.13.2",
     "coingecko-api": "1.0.10",

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,6 +13,7 @@ async function bootstrap()
     const app: NestFastifyApplication = await NestFactory.create<NestFastifyApplication>(
         AppModule,
         new FastifyAdapter(),
+        { cors: true },
     );
     const configService: ConfigService = app.get(ConfigService);
     const PORT: string =  <string>configService.get<string>("PORT");

--- a/src/services/onchain-data.service.ts
+++ b/src/services/onchain-data.service.ts
@@ -71,13 +71,12 @@ export class OnchainDataService implements OnModuleInit
             const token1Address: string = ethers.utils.getAddress((await pairContract.method(token1ABI).call())
                 .decoded[0]);
 
-            const token0: IToken = await this.mutex.runExclusive(() =>
+            const [token0, token1] = await this.mutex.runExclusive(() =>
             {
-                return this.fetchToken(token0Address);
-            });
-            const token1: IToken = await this.mutex.runExclusive(() =>
-            {
-                return this.fetchToken(token1Address);
+                return Promise.all([
+                    this.fetchToken(token0Address),
+                    this.fetchToken(token1Address),
+                ]);
             });
 
             const { reserve0, reserve1 } = (


### PR DESCRIPTION
Would like some advice / perspectives on this: I discovered a race condition within the `fetchToken` function. 

As each pair fetching is a promise executed in parallel, between checking for 

```js
if (address in this.tokens) return this.tokens[address]
```

and writing to state

```js
this.tokens[address] = token
```

there are a bunch of await statements to fetch data from the blockchain. This is when another pair comes in and sees that the pair doesn't yet exist (cuz another operation is fetching it!), and continues the mess. This only happens for the first fetching on init. 

Happy to hear other better suggestions that can solve this without the use of mutex. 
