### PR TITLE
feat: removing unexpected pairs and tokens

### DIFF
--- a/src/services/onchain-data.service.ts
+++ b/src/services/onchain-data.service.ts
@@ -203,8 +203,10 @@ export class OnchainDataService implements OnModuleInit
         for (const pairAddress in this.pairs)
         {
             // Filters out pairs where either one token is an LP token
-            if (this.pairs[pairAddress].token0.contractAddress in this.pairs
-              || this.pairs[pairAddress].token1.contractAddress in this.pairs)
+            if (
+                   this.pairs[pairAddress].token0.contractAddress in this.pairs
+                || this.pairs[pairAddress].token1.contractAddress in this.pairs
+               )
             {
                 delete this.pairs[pairAddress];
             }

--- a/src/services/onchain-data.service.ts
+++ b/src/services/onchain-data.service.ts
@@ -140,6 +140,7 @@ export class OnchainDataService implements OnModuleInit
         });
         await Promise.all(promises);
         this.calculateUsdPrices();
+        this.filterNonStandardPairsTokens();
     }
 
     private async fetchToken(address: string): Promise<IToken>
@@ -193,6 +194,26 @@ export class OnchainDataService implements OnModuleInit
             {
                 this.tokens[pair.token0.contractAddress].usdPrice =
                   this.coingeckoService.getVetPrice() / parseFloat(pair.price);
+            }
+        }
+    }
+
+    private filterNonStandardPairsTokens(): void
+    {
+        for (const pairAddress in this.pairs)
+        {
+            // Filters out pairs where either one token is an LP token
+            if (this.pairs[pairAddress].token0.contractAddress in this.pairs
+              || this.pairs[pairAddress].token1.contractAddress in this.pairs)
+            {
+                delete this.pairs[pairAddress];
+            }
+        }
+        for (const tokenAddress in this.tokens)
+        {
+            if (this.tokens[tokenAddress].usdPrice === undefined)
+            {
+                delete this.tokens[tokenAddress];
             }
         }
     }

--- a/src/services/onchain-data.service.ts
+++ b/src/services/onchain-data.service.ts
@@ -140,7 +140,7 @@ export class OnchainDataService implements OnModuleInit
         });
         await Promise.all(promises);
         this.calculateUsdPrices();
-        this.filterNonStandardPairsTokens();
+        this.filterMissingUsdTokens();
     }
 
     private async fetchToken(address: string): Promise<IToken>
@@ -198,19 +198,8 @@ export class OnchainDataService implements OnModuleInit
         }
     }
 
-    private filterNonStandardPairsTokens(): void
+    private filterMissingUsdTokens(): void
     {
-        for (const pairAddress in this.pairs)
-        {
-            // Filters out pairs where either one token is an LP token
-            if (
-                   this.pairs[pairAddress].token0.contractAddress in this.pairs
-                || this.pairs[pairAddress].token1.contractAddress in this.pairs
-               )
-            {
-                delete this.pairs[pairAddress];
-            }
-        }
         for (const tokenAddress in this.tokens)
         {
             if (this.tokens[tokenAddress].usdPrice === undefined)


### PR DESCRIPTION
Do yall think we should have a flag in the GET request, e.g. `showHidden=true` so that one day if some people need the raw unfiltered list of pairs, they can get them? It will default to `false` and return the list for general consumption 